### PR TITLE
Point submodules to same repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,24 +1,24 @@
 [submodule "01-wait-forever"]
 	path = 01-wait-forever
-	url = ssh://git@github.com/RustOS2/rust-raspberrypi-OS-tutorials
+	url = https://github.com/RustOS2/flamingos.git
 	branch = 01-wait-forever
 [submodule "02-runtime-init"]
 	path = 02-runtime-init
-	url = ssh://git@github.com/RustOS2/rust-raspberrypi-OS-tutorials
+	url = https://github.com/RustOS2/flamingos.git
 	branch = 02-runtime-init
 [submodule "03-hacky-hello-world"]
 	path = 03-hacky-hello-world
-	url = ssh://git@github.com/RustOS2/rust-raspberrypi-OS-tutorials
+	url = https://github.com/RustOS2/flamingos.git
 	branch = 03-hacky-hello-world
 [submodule "04-safe-globals"]
 	path = 04-safe-globals
-	url = ssh://git@github.com/RustOS2/rust-raspberrypi-OS-tutorials
+	url = https://github.com/RustOS2/flamingos.git
 	branch = 04-safe-globals
 [submodule "05-drivers-gpio-uart"]
 	path = 05-drivers-gpio-uart
-	url = ssh://git@github.com/RustOS2/rust-raspberrypi-OS-tutorials
+	url = https://github.com/RustOS2/flamingos.git
 	branch = 05-drivers-gpio-uart
 [submodule "06-uart-chainloader"]
 	path = 06-uart-chainloader
-	url = ssh://git@github.com/RustOS2/rust-raspberrypi-OS-tutorials
+	url = https://github.com/RustOS2/flamingos.git
 	branch = 06-uart-chainloader


### PR DESCRIPTION
### Description

<Please describe the issues fixed by this PR>

Related Issue: <Insert link here if applicable>

### Pre-commit steps

 - [ ] Tested on QEMU and real HW Rasperry Pi.
     - Not needed if it is just a README change or similar.
 - [ ] Ran `./contributor_setup.sh` followed by `./devtool ready_for_publish`
     - You'll need `Ruby` with `Bundler` and `NPM` installed locally.
     - If no Rust-related files were changed, `./devtool ready_for_publish_no_rust` can be used instead (faster).
     - This step is optional, but much appreciated if done.
